### PR TITLE
Update schedule drag handle

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
                 <table class="schedule-table"> <!-- Note: may need fixing -->
   <thead>
     <tr>
-      <th></th>  <!-- drag handle -->
       <th>Period</th>
       <th>Sun</th>
       <th>Mon</th>
@@ -331,31 +330,30 @@ Just type naturally!"></textarea>
 
     entries.forEach(([period, days]) => {
         const row = document.createElement('tr');
-        row.draggable = true;
         row.dataset.period = period;
-        row.addEventListener('dragstart', (e) => {
-    e.dataTransfer.setData('text/plain', period); // Save the dragged period name
-});
+        row.draggable = false;
         
 
 
-        // Drag handle cell ☰
-        const dragCell = document.createElement('td');
-        dragCell.textContent = '☰';
-        dragCell.style.cursor = 'grab';
-        dragCell.style.textAlign = 'center';
-        dragCell.style.color = '#888';
-        dragCell.style.width = '30px';
-        dragCell.style.userSelect = 'none';
-        dragCell.style.fontSize = '18px';
-        row.appendChild(dragCell);
 
         // Period cell
         const periodCell = document.createElement('td');
+        periodCell.classList.add('period-cell');
         periodCell.contentEditable = true;
         periodCell.textContent = period;
         periodCell.style.fontWeight = 'bold';
         periodCell.style.background = '#f8f9ff';
+
+        const handle = document.createElement('span');
+        handle.className = 'drag-handle';
+        handle.textContent = '☰';
+        handle.draggable = true;
+        handle.contentEditable = false;
+        handle.addEventListener('dragstart', (e) => {
+            e.dataTransfer.setData('text/plain', period);
+        });
+        periodCell.prepend(handle);
+
         periodCell.addEventListener('blur', () => {
             const newPeriod = periodCell.textContent.trim();
             if (newPeriod !== period && newPeriod) {
@@ -399,9 +397,6 @@ Just type naturally!"></textarea>
         
 
         // Drag events
-        row.addEventListener('dragstart', (e) => {
-            e.dataTransfer.setData('text/plain', period);
-        });
 
         row.addEventListener('dragover', (e) => {
             e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -1,18 +1,30 @@
 
-     td:first-child {
-    font-size: 18px;
-    text-align: center;
-    cursor: grab;
-    color: #888;
-    user-select: none;
-    width: 30px;
-  }
-
-
-
-        
-        .course-wrapper {
+.course-wrapper {
   cursor: grab;
+}
+
+
+.period-cell {
+  position: relative;
+  padding-left: 22px; /* room for drag handle */
+}
+
+
+.drag-handle {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 18px;
+  color: #888;
+  cursor: grab;
+  user-select: none;
+  display: none;
+}
+
+tr:hover .drag-handle,
+.drag-handle:hover {
+  display: inline;
 }
   
         


### PR DESCRIPTION
## Summary
- inline drag handle inside period cells
- style `.period-cell` and `.drag-handle`
- remove old drag handle column
- update schedule display logic for handle-based dragging
- fix handle positioning and make it non-editable

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dce51c01c83338fdfac0860eadd03