### PR TITLE
Update schedule to drive timer from user times

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     <tr>
       <th></th>  <!-- drag handle -->
       <th>Period</th>
+      <th>Time</th>
       <th>Sun</th>
       <th>Mon</th>
       <th>Tue</th>
@@ -278,23 +279,23 @@ Just type naturally!"></textarea>
         // Schedule management Note: May need fixing
         function initializeSchedule() {
             const defaultPeriods = [
-                'Wakeup (7:30)',
-                'P1 (8-9:45)',
-                'P2 (10-11:45)',
-                'Lunch (12-1)',
-                'P3 (1-2:45)',
-                'P4 (3-4:45)',
-                'P5 (5-6:45)',
-                'P6 (7-8:45)',
-                'P7 (9-9:45)',
-                'Sleep (10-10:30)'
+                { name: 'Wakeup', time: '7:30-8:00' },
+                { name: 'P1', time: '8:00-9:45' },
+                { name: 'P2', time: '10:00-11:45' },
+                { name: 'Lunch', time: '12:00-1:00' },
+                { name: 'P3', time: '1:00-2:45' },
+                { name: 'P4', time: '3:00-4:45' },
+                { name: 'P5', time: '5:00-6:45' },
+                { name: 'P6', time: '7:00-8:45' },
+                { name: 'P7', time: '9:00-9:45' },
+                { name: 'Sleep', time: '10:00-10:30' }
             ];
 //NOTE(!appData.schedule[weekKey])
             const weekKey = getWeekKey();
-            if (!appData.schedule[weekKey]) { 
+            if (!appData.schedule[weekKey]) {
                 appData.schedule[weekKey] = {};
-                defaultPeriods.forEach(period => {
-                    appData.schedule[weekKey][period] = ['', '', '', '', '', '', ''];
+                defaultPeriods.forEach(p => {
+                    appData.schedule[weekKey][p.name] = { time: p.time, days: ['', '', '', '', '', '', ''] };
                 });
             }
             
@@ -327,7 +328,8 @@ Just type naturally!"></textarea>
 
     const entries = Object.entries(scheduleData);
 
-    entries.forEach(([period, days]) => {
+    entries.forEach(([period, info]) => {
+        const days = info.days;
         const row = document.createElement('tr');
         row.draggable = true;
         row.dataset.period = period;
@@ -348,7 +350,7 @@ Just type naturally!"></textarea>
         dragCell.style.fontSize = '18px';
         row.appendChild(dragCell);
 
-        // Period cell
+        // Period name cell
         const periodCell = document.createElement('td');
         periodCell.contentEditable = true;
         periodCell.textContent = period;
@@ -364,6 +366,17 @@ Just type naturally!"></textarea>
             }
         });
         row.appendChild(periodCell);
+
+        // Time cell
+        const timeCell = document.createElement('td');
+        timeCell.contentEditable = true;
+        timeCell.textContent = info.time || '';
+        timeCell.addEventListener('blur', () => {
+            scheduleData[period].time = timeCell.textContent.trim();
+            saveData();
+            updateCurrentActivity();
+        });
+        row.appendChild(timeCell);
         
 
         // Day cells (Sunday-start week, order matches table: Sun, Mon, Tue, Wed, Thu, Fri, Sat)
@@ -373,7 +386,7 @@ Just type naturally!"></textarea>
             cell.contentEditable = true;
             cell.textContent = days[dayOrder[i]] || '';
             cell.addEventListener('blur', () => {
-                scheduleData[period][dayOrder[i]] = cell.textContent;
+                scheduleData[period].days[dayOrder[i]] = cell.textContent;
                 saveData();
             });
             
@@ -431,6 +444,7 @@ Just type naturally!"></textarea>
 
         tbody.appendChild(row);
     });
+    updateCurrentActivity();
 }
 
 
@@ -441,7 +455,7 @@ Just type naturally!"></textarea>
             }
             
             const newPeriod = `New Period ${Object.keys(appData.schedule[weekKey]).length + 1}`;
-            appData.schedule[weekKey][newPeriod] = ['', '', '', '', '', '', ''];
+            appData.schedule[weekKey][newPeriod] = { time: '', days: ['', '', '', '', '', '', ''] };
             updateScheduleDisplay();
             saveData();
         }
@@ -470,27 +484,52 @@ Just type naturally!"></textarea>
             document.getElementById('currentTime').textContent = timeString;
         }
 
+        function parseTimeRange(range, prevHour = null) {
+            if (!range) return null;
+            const [startStr, endStr] = range.split('-').map(p => p.trim());
+            if (!startStr || !endStr) return null;
+
+            const parse = (str, base) => {
+                const [h, m] = str.split(':').map(Number);
+                if (isNaN(h) || isNaN(m)) return null;
+                let hour = h;
+                if (base !== null && hour < base) hour += 12;
+                return { hour, minute: m, total: hour * 60 + m };
+            };
+
+            const start = parse(startStr, prevHour);
+            if (!start) return null;
+            const end = parse(endStr, start.hour);
+            if (!end) return null;
+
+            return { start: start.total, end: end.total, endHour: end.hour };
+        }
+
+        function getTimeSlots() {
+            const weekKey = getWeekKey();
+            const scheduleData = appData.schedule[weekKey] || {};
+            const slots = [];
+            let prev = 0;
+            for (const [name, info] of Object.entries(scheduleData)) {
+                const res = parseTimeRange(info.time, prev);
+                if (res) {
+                    slots.push({ start: res.start, end: res.end, name, time: info.time });
+                    prev = res.endHour;
+                }
+            }
+            return slots;
+        }
+
         function updateCurrentActivity() {
             const now = new Date();
             const currentTime = now.getHours() * 60 + now.getMinutes();
-            
-            const timeSlots = [
-                { start: 450, end: 480, activity: "Wake up time! ☀️" },
-                { start: 480, end: 585, activity: "Period 1 (8:00-9:45)" },
-                { start: 600, end: 705, activity: "Period 2 (10:00-11:45)" },
-                { start: 720, end: 780, activity: "Lunch Break 🍽️" },
-                { start: 780, end: 885, activity: "Period 3 (1:00-2:45)" },
-                { start: 900, end: 1005, activity: "Period 4 (3:00-4:45)" },
-                { start: 1020, end: 1125, activity: "Period 5 (5:00-6:45)" },
-                { start: 1140, end: 1245, activity: "Period 6 (7:00-8:45)" },
-                { start: 1260, end: 1305, activity: "Period 7 (9:00-9:45)" },
-                { start: 1320, end: 1350, activity: "Sleep time 😴" }
-            ];
+
+            const timeSlots = getTimeSlots();
 
             let currentActivity = "Free time";
             for (const slot of timeSlots) {
                 if (currentTime >= slot.start && currentTime < slot.end) {
-                    currentActivity = slot.activity;
+                    currentActivity = `${slot.name} (${slot.time})`;
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- parse user-entered period times to minutes
- generate `timeSlots` dynamically from the schedule
- refresh current activity whenever schedule times change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd543d3c88333b5278e0c9f59633a